### PR TITLE
Do not request provisional access

### DIFF
--- a/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
+++ b/packages/messaging/ios/RNFBMessaging/RNFBMessagingModule.m
@@ -145,12 +145,7 @@ RCT_EXPORT_METHOD(requestPermission:
 
   RCTPromiseResolveBlock customResolver = ^(id result) {
     if (@available(iOS 10.0, *)) {
-      UNAuthorizationOptions authOptions;
-      if (@available(iOS 12.0, *)) {
-        authOptions = UNAuthorizationOptionProvisional | UNAuthorizationOptionAlert | UNAuthorizationOptionSound | UNAuthorizationOptionBadge;
-      } else {
-        authOptions = UNAuthorizationOptionAlert | UNAuthorizationOptionSound | UNAuthorizationOptionBadge;
-      }
+      UNAuthorizationOptions authOptions = UNAuthorizationOptionAlert | UNAuthorizationOptionSound | UNAuthorizationOptionBadge;
 
       [[UNUserNotificationCenter currentNotificationCenter] requestAuthorizationWithOptions:authOptions completionHandler:^(BOOL granted, NSError *_Nullable error) {
         if (error) {


### PR DESCRIPTION
This PR disables requesting Provisional Access to user's notifications settings when _iOS_  >= 12.